### PR TITLE
Bump Java, add Pyspark and Pandas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u342-jre
 
 RUN apt-get update \
- && apt-get install --assume-yes telnet python3 python3-pip procps \
+ && apt-get install --assume-yes python3 python3-pip procps \
  && apt-get clean
 
 RUN pip3 install pyspark~=3.3.1 pandas~=1.5.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM openjdk:8u242-jre
+FROM openjdk:8u342-jre
+
+RUN apt-get update \
+ && apt-get install --assume-yes telnet python3 python3-pip procps \
+ && apt-get clean
+
+RUN pip3 install pyspark~=3.3.1 pandas~=1.5.3
 
 WORKDIR /opt
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It contains following containers:
 - mariadb as dependency
 - minio to test S3 access (make sure that you specify correct volume to be mounted)
 - hive metastore  3.x
+- Pyspark 3.3.x and Pandas
 
 ### How to run
 


### PR DESCRIPTION
I needed a simple env to experiment with Pyspark and Spark 3, so I took your base and added extra stuff. 

procps is needed for Pyspark
