### PR TITLE
Do not fail on first run of MariaDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM openjdk:8u242-jre
 
+RUN apt-get update \
+ && apt-get install --assume-yes telnet \
+ && apt-get clean
+
 WORKDIR /opt
 
 ENV HADOOP_VERSION=3.2.0

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,5 +4,26 @@ export HADOOP_HOME=/opt/hadoop-3.2.0
 export HADOOP_CLASSPATH=${HADOOP_HOME}/share/hadoop/tools/lib/aws-java-sdk-bundle-1.11.375.jar:${HADOOP_HOME}/share/hadoop/tools/lib/hadoop-aws-3.2.0.jar
 export JAVA_HOME=/usr/local/openjdk-8
 
-/opt/apache-hive-metastore-3.0.0-bin/bin/schematool -initSchema -dbType mysql
+# Make sure mariadb is ready
+MAX_TRIES=8
+CURRENT_TRY=1
+SLEEP_BETWEEN_TRY=4
+until [ "$(telnet mariadb 3306 | sed -n 2p)" = "Connected to mariadb." ] || [ "$CURRENT_TRY" -gt "$MAX_TRIES" ]; do
+    echo "Waiting for mariadb server..."
+    sleep "$SLEEP_BETWEEN_TRY"
+    CURRENT_TRY=$((CURRENT_TRY + 1))
+done
+
+if [ "$CURRENT_TRY" -gt "$MAX_TRIES" ]; then
+  echo "WARNING: Timeout when waiting for mariadb."
+fi
+
+# Check if schema exists
+/opt/apache-hive-metastore-3.0.0-bin/bin/schematool -dbType mysql -info
+
+if [ $? -eq 1 ]; then
+  echo "Getting schema info failed. Probably not initialized. Initializing..."
+  /opt/apache-hive-metastore-3.0.0-bin/bin/schematool -initSchema -dbType mysql
+fi
+
 /opt/apache-hive-metastore-3.0.0-bin/bin/start-metastore


### PR DESCRIPTION
When MariaDB starts for the first time, creates bunch of internal tables. By using telnet, we can make sure to interact with it, only after it is ready to accept connections.

Also create schema in metastore, only if it was not created in the past, by getting info first.